### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
@@ -133,7 +133,7 @@ object Command extends App
   }
 
   result.map(msg => Console.err.println(s"OK: $msg"))
-    .onError(e => Console.err.println(s"FAILED: ${ e.getMessage }"))
+    .doIfFailure { case e => Console.err.println(s"FAILED: ${ e.getMessage }") }
 
   private def getUserList(domain: String): Try[Seq[String]] = {
     for {

--- a/src/main/scala/nl.knaw.dans.easy.springfield/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/package.scala
@@ -17,8 +17,6 @@ package nl.knaw.dans.easy
 
 import java.util.Properties
 
-import scala.util.{ Failure, Success, Try }
-
 package object springfield {
   case class SpringfieldErrorException(errorCode: Int, message: String, details: String) extends Exception(s"($errorCode) $message: $details")
 
@@ -29,16 +27,6 @@ package object springfield {
       val props = new Properties()
       props.load(getClass.getResourceAsStream("/Version.properties"))
       props.getProperty("application.version")
-    }
-  }
-
-  implicit class TryExtensions[T](val t: Try[T]) extends AnyVal {
-    // TODO candidate for dans-scala-lib, see also implementation/documentation in easy-split-multi-deposit
-    def onError[S >: T](handle: Throwable => S): S = {
-      t match {
-        case Success(value) => value
-        case Failure(throwable) => handle(throwable)
-      }
     }
   }
 }


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* use the `dans-scala-lib` functions

@DANS-KNAW/easy for review