### PR TITLE
EASY-1773: Add audio files to require ticket method

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
@@ -109,7 +109,7 @@ object Command extends App
       }
     case Some(cmd @ opts.setRequireTicket) =>
       for {
-        videos <- getReferencedPaths(cmd.path()).map(_.filter(p => p.getNameCount > 1 && Set("audio", "video").contains(p.getName(p.getNameCount - 2).toString)))
+        videos <- getReferencedPaths(cmd.path()).map(_.filter(p => p.getNameCount > 1 && avNames.contains(p.getName(p.getNameCount - 2).toString)))
         _ <- approveAction(videos,
           s"""
              |WARNING: THIS ACTION COULD EXPOSE VIDEOS TO UNAUTHORIZED VIEWERS.

--- a/src/main/scala/nl.knaw.dans.easy.springfield/Smithers2.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Smithers2.scala
@@ -21,10 +21,11 @@ import java.nio.file.{ Path, Paths }
 
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import scalaj.http.{ Http, HttpResponse }
+import scalaj.http.Http
 
 import scala.util.{ Failure, Success, Try }
 import scala.xml.{ Elem, XML }
+
 
 trait Smithers2 {
   this: DebugEnhancedLogging =>
@@ -39,7 +40,6 @@ trait Smithers2 {
     debug(s"Smithers2 URI: $uri")
     for {
       response <- http("GET", uri)
-      _ = logResponseBody(response)
       if response.code == 200
       xml <- checkResponseOk(response.body)
     } yield xml
@@ -74,15 +74,9 @@ trait Smithers2 {
     debug(s"Smithers2 URI: $uri")
     for {
       response <- http("PUT", uri, requireTicket.toString)
-      _ = logResponseBody(response)
       if response.code == 200
       _ <- checkResponseOk(response.body)
     } yield ()
-  }
-
-  private def logResponseBody(response: HttpResponse[Array[Byte]]): Unit = {
-    val xml = XML.load(new ByteArrayInputStream(response.body))
-    logger.info(s"response body = ${ xml }")
   }
 
   /**
@@ -200,6 +194,7 @@ trait Smithers2 {
       if response.code == 200
       _ <- checkResponseOk(response.body)
     } yield ()
+
   }
 
   def addPresentationRefToCollection(presentationReferId: Path, presentationName: String, collection: Path): Try[Unit] = {
@@ -237,10 +232,12 @@ trait Smithers2 {
     else Failure(new IllegalArgumentException(s"$collection does not appear to be a collection Springfield path. Expected format: [domain/<d>/]user/<u>/collection/<name>"))
   }
 
+
   def checkNameLength(name: String): Try[Unit] = {
     if (name.length <= MAX_NAME_LENGTH) Success(())
     else Failure(new IllegalArgumentException(s"Name is longer than 100 chars: $name"))
   }
+
 
   def getCompletePath(path: Path): Path = {
     if (path.getName(0).toString == "domain") path
@@ -263,6 +260,7 @@ trait Smithers2 {
       .timeout(connTimeoutMs = smithers2ConnectionTimeoutMs, readTimeoutMs = smithers2ReadTimoutMs)
       .asBytes
   }
+
 
   def checkResponseOk(content: Array[Byte]): Try[Elem] = {
     /*


### PR DESCRIPTION

fixes EASY-1773

#### When applied it will
*  the require-ticket command will also change the /properties/private tribute of audio files

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 