### PR TITLE
EASY-2040 add prolog and xlmns to create Springfield actions

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
@@ -42,6 +42,7 @@ object Command extends App
 
   type FeedBackMessage = String
 
+  private val prologue = "<?xml version='1.0' encoding='UTF-8'?>"
   private val avNames = Set("audio", "video")
   private val opts = new CommandLineOptions(args, config)
   opts.verify()
@@ -72,7 +73,7 @@ object Command extends App
         actions <- createSpringfieldActions(videos)
       } yield (new PrettyPrinter(160, 2).format(actions), parentsToCreate)
       result.map { case (s, ps) =>
-        println(s)
+        println(addPrologue(s))
         "XML generated." + (if (!cmd.videosFolder.isSupplied) " (Existence of files has NOT been checked!)"
                             else "") +
           (if (cmd.checkParentItems()) {
@@ -215,4 +216,6 @@ object Command extends App
     if (StdIn.readLine().toLowerCase == "y") Success(list)
     else Failure(new Exception("User aborted action"))
   }
+
+  private def addPrologue(xml: String): String = s"$prologue\n$xml"
 }

--- a/src/main/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActions.scala
@@ -68,7 +68,7 @@ trait CreateSpringfieldActions {
   }
 
   def createSpringfieldActions(videos: Seq[Video]): Try[Elem] = Try {
-    <actions>
+    <actions xmlns="springfield-actions">
       { createAddPresentations(videos) }
     </actions>
   }
@@ -93,6 +93,6 @@ trait CreateSpringfieldActions {
   }
 
   def createAddVideo(srcVideo: Path, fileName: String): Elem = {
-      <video src={srcVideo.toString} target={fileName}/>
+      <video src={srcVideo.toString} target={fileName} title={} />
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActions.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActions.scala
@@ -93,6 +93,6 @@ trait CreateSpringfieldActions {
   }
 
   def createAddVideo(srcVideo: Path, fileName: String): Elem = {
-      <video src={srcVideo.toString} target={fileName} title={} />
+      <video src={srcVideo.toString} target={fileName}/>
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
@@ -19,8 +19,12 @@ import java.nio.file.Paths
 
 import org.scalatest.Inside
 
+import scala.util.Success
+import scala.xml.Elem
+
 class CreateSpringfieldActionsSpec extends TestSupportFixture with Inside with CreateSpringfieldActions {
   val defaultDomain = "dans"
+  private val springFieldActionsNameSpace: String = "springfield-actions"
 
   "createAddVideo" should "return a filled-in video element" in {
     val videoElem = createAddVideo(Paths.get("/my/source/vid.mp4"), "vid01.mp4")
@@ -62,5 +66,10 @@ class CreateSpringfieldActionsSpec extends TestSupportFixture with Inside with C
     }
   }
 
-
+  "createSpringfieldActions" should "should have a name space in the root element 'actions'" in {
+    val video = Video(Paths.get("a/path/to/somewhere"), "dans", "utest", "1", "2", "3", requireTicket = false)
+    createSpringfieldActions(Seq(video)) should matchPattern {
+      case Success(n: Elem) if n.namespace == springFieldActionsNameSpace =>
+    }
+  }
 }

--- a/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
@@ -66,7 +66,7 @@ class CreateSpringfieldActionsSpec extends TestSupportFixture with Inside with C
     }
   }
 
-  "createSpringfieldActions" should "should have a name space in the root element 'actions'" in {
+  "createSpringfieldActions" should "have a name-space in the root element 'actions'" in {
     val video = Video(Paths.get("a/path/to/somewhere"), "dans", "utest", "1", "2", "3", requireTicket = false)
     createSpringfieldActions(Seq(video)) should matchPattern {
       case Success(n: Elem) if n.namespace == springFieldActionsNameSpace =>

--- a/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
@@ -66,7 +66,7 @@ class CreateSpringfieldActionsSpec extends TestSupportFixture with Inside with C
     }
   }
 
-  "createSpringfieldActions" should "have a name-space in the root element 'actions'" in {
+  "createSpringfieldActions" should "have a namespace in the root element 'actions'" in {
     val video = Video(Paths.get("a/path/to/somewhere"), "dans", "utest", "1", "2", "3", requireTicket = false)
     createSpringfieldActions(Seq(video)) should matchPattern {
       case Success(n: Elem) if n.namespace == springFieldActionsNameSpace =>


### PR DESCRIPTION
fixes EASY-2040

#### When applied it will
* add prolog and xlmns to create Springfield actions

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-schema                      | [PR#69](https://github.com/DANS-KNAW/easy-schema/pull/69) 