### PR TITLE
EASY-2131: Find videos in collection / presentation by @ID

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.springfield/AddSubtitles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/AddSubtitles.scala
@@ -64,17 +64,17 @@ trait AddSubtitles extends DebugEnhancedLogging {
    * @param subtitles    a list of paths to the to be added subtitles files
    * @return
    */
-  def addSubtitlesToPresentation(videoNumber: Int, language: String, presentation: Path, subtitles: List[Path]): Try[Unit] = {
-    subtitles match {
+  def addSubtitlesToPresentation(language: String, presentation: Path, subtitlesWithVideoIds: List[VideoPathWithId]): Try[Unit] = {
+    subtitlesWithVideoIds match {
       case Nil => Success(())
       case head :: tail =>
-        val relativePathToVideoProps = s"videoplaylist/1/video/$videoNumber"
+        val relativePathToVideoProps = s"videoplaylist/1/video/${ head.id }"
         val pathToPresentation = presentation.resolve(relativePathToVideoProps)
         for {
-          videoRef <- getVideoRefIdForVideoInPresentation(presentation, String.valueOf(videoNumber))
-          _ <- addSubtitlesToVideo(head, Paths.get(videoRef), language) // first add the subtitles to the video, before adding it to the presentation
+          videoRef <- getVideoRefIdForVideoInPresentation(presentation, head.id)
+          _ <- addSubtitlesToVideo(head.path, Paths.get(videoRef), language) // first add the subtitles to the video, before adding it to the presentation
           _ = debug(s"added '$head' to presentation '$pathToPresentation'")
-          _ <- addSubtitlesToPresentation(videoNumber + 1, language, presentation, tail)
+          _ <- addSubtitlesToPresentation(language, presentation, tail)
         } yield ()
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
@@ -151,8 +151,10 @@ object Command extends App
         _ <- checkPathIsRelative(cmd.presentation())
         completePath = getCompletePath(cmd.presentation())
         presentationRefId <- getPresentationReferIdPath(completePath)
-        _ <- validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(presentationRefId, cmd.subtitles())
-        _ <- addSubtitlesToPresentation(1, cmd.languageCode(), presentationRefId, cmd.subtitles())
+        videos <- getVideoIdsForPresentation(completePath)
+        _ <- validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(videos, cmd.subtitles())
+        videoPathsWithIds = zipVideoPathsWithIds(cmd.subtitles(), videos)
+        _ <- addSubtitlesToPresentation(cmd.languageCode(), presentationRefId, videoPathsWithIds)
       } yield "Subtitles added to presentation"
     case Some(cmd @ opts.showAvailableLanguageCodes) =>
       println(config.languages.mkString("\n"))

--- a/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Command.scala
@@ -159,7 +159,7 @@ object Command extends App
         _ <- checkPathIsRelative(cmd.presentation())
         completePath = getCompletePath(cmd.presentation())
         presentationRefId <- getPresentationReferIdPath(completePath)
-        videos <- getVideoIdsForPresentation(completePath)
+        videos <- getVideoIdsForPresentation(presentationRefId)
         _ <- validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(videos, cmd.subtitles())
         videoPathsWithIds = zipVideoPathsWithIds(cmd.subtitles(), videos)
         _ <- addSubtitlesToPresentation(cmd.languageCode(), presentationRefId, videoPathsWithIds)

--- a/src/main/scala/nl.knaw.dans.easy.springfield/SetPlaymode.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/SetPlaymode.scala
@@ -46,18 +46,13 @@ trait SetPlaymode extends DebugEnhancedLogging {
    * Sets the playmode for playlist in a presentation. The path must point to the
    * actual playlist resource.
    *
-   * @param videoPlayListInPresentationPath path to the playlist in the presentation
-   * @param mode                            {menu|continuous} the to be played mode
+   * @param referId path to the playlist in the presentation
+   * @param mode    {menu|continuous} the to be played mode
    */
-  private def setPlayModeForVideoPlayListInPresentation(videoPlayListInPresentationPath: Path, mode: Playmode): Try[Unit] = {
-    trace(videoPlayListInPresentationPath, mode)
-    val uri = path2Uri(videoPlayListInPresentationPath.resolve("properties").resolve("play-mode"))
-    debug(s"Smithers2 URI: $uri")
-    sendRequestAndCheckResponse(uri, "PUT", mode.toString)
-  }
-
   private def setPlayModeForPlayLists(referId: Path, mode: Playmode, ids: Seq[String]): Try[Unit] = {
-    ids.map(id => setPlayModeForVideoPlayListInPresentation(referId.resolve(s"videoplaylist").resolve(id), mode))
-      .collectFirst { case f @ Failure(_) => f }.getOrElse(Success(()))
+    ids
+      .map(id => setProperty(referId.resolve(s"videoplaylist").resolve(id).resolve("properties").resolve("play-mode"), mode.toString))
+      .collectFirst { case Failure(exception) => Failure(new IllegalStateException(exception.getMessage)) }
+      .getOrElse(Success(()))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.springfield/Smithers2.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/Smithers2.scala
@@ -203,7 +203,11 @@ trait Smithers2 {
   }
 
   private def createReferidEnvelope(presentationReferId: Path): String = {
-    <fsxml><attributes><referid>{ "/" + getCompletePath(presentationReferId).toString }</referid></attributes></fsxml>.toString
+    <fsxml>
+      <attributes>
+        <referid>{ "/" + getCompletePath(presentationReferId).toString }</referid>
+      </attributes>
+    </fsxml>.toString
   }
 
   def validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(videos: List[String], subtitles: List[Path]): Try[Unit] = {
@@ -313,7 +317,7 @@ trait Smithers2 {
   }
 
   private def sendRequestAndCheckResponse(uri: URI, method: String, body: String = null): Try[Unit] = {
-    http(method, uri)
+    http(method, uri, body)
       .map(response => if (response.code == 200) checkResponseOk(response.body))
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.springfield/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.springfield/package.scala
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.easy
 
+import java.nio.file.Path
+
 package object springfield {
   case class SpringfieldErrorException(errorCode: Int, message: String, details: String) extends Exception(s"($errorCode) $message: $details")
+  case class VideoPathWithId(path: Path, id: String)
 
   val MAX_NAME_LENGTH = 100
 

--- a/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/CreateSpringfieldActionsSpec.scala
@@ -61,6 +61,4 @@ class CreateSpringfieldActionsSpec extends TestSupportFixture with Inside with C
         v2.attribute("target").get.head.text shouldBe "vid02.mp4"
     }
   }
-
-
 }

--- a/src/test/scala/nl.knaw.dans.easy.springfield/Smithers2Spec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/Smithers2Spec.scala
@@ -39,6 +39,8 @@ class Smithers2Spec extends TestSupportFixture
             </video>
             <video id="2" referid="/domain/dans/user/utest/video/7">
             </video>
+              <video id="id that contains words" referid="/domain/dans/user/utest/video/7">
+            </video>
           </videoplaylist>
         </presentation>
       </fsxml>
@@ -67,14 +69,14 @@ class Smithers2Spec extends TestSupportFixture
 
   it should "fail if a non existing index is given" in {
     extractVideoRefFromPresentationForVideoId("3")(elem) should matchPattern {
-      case Failure(i: IllegalStateException) if i.getMessage == "No videoReference found for index '3' in the presentation" =>
+      case Failure(i: IllegalStateException) if i.getMessage == "No videoReference found for id '3' in the presentation" =>
     }
   }
 
   it should "fail if a malformed xml-elem is provided" in {
     val malFormedElem = <mal><formed><elem></elem></formed></mal>
     extractVideoRefFromPresentationForVideoId("1")(malFormedElem) should matchPattern {
-      case Failure(i: IllegalStateException) if i.getMessage == "No videoReference found for index '1' in the presentation" =>
+      case Failure(i: IllegalStateException) if i.getMessage == "No videoReference found for id '1' in the presentation" =>
     }
   }
 
@@ -201,32 +203,43 @@ class Smithers2Spec extends TestSupportFixture
     getCompletePath(completePath) shouldBe completePath
   }
 
-  "getNumberOfVideos" should "return the number of videos" in {
-    getNumberOfVideos(elem) shouldBe 2
+  "zipVideoPathsWithIds" should "should return an empty list if no video id's are given" in {
+    zipVideoPathsWithIds(List(Paths.get("domain/dans/user/utest/presentation/1")), List()) shouldBe List()
   }
 
-  it should "return 0 if there are no videos present" in {
-    getNumberOfVideos(<empty/>) shouldBe 0
+  it should "discard excessive ids" in {
+    zipVideoPathsWithIds(List(Paths.get("domain/dans/user/utest/presentation/3")), List("1", "2")) shouldBe List(VideoPathWithId(Paths.get("domain/dans/user/utest/presentation/3"), "1"))
   }
 
-  "validateNumberOfVideosIsSameAsNumberOfSubtitles" should "succeed if the number of subtitles '0' is equal to the number of videos in the presentation '0'" in {
-    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(Paths.get("domain/dans/user/utest/presentation/1"), List()) shouldBe a[Success[_]]
+  it should "return a list of tuples if an even number of paths and ids is provided" in {
+    zipVideoPathsWithIds(List(Paths.get("domain/dans/user/utest/presentation/1"), Paths.get("domain/dans/user/utest/presentation/2")), List("1", "2")) shouldBe List(
+      VideoPathWithId(Paths.get("domain/dans/user/utest/presentation/1"), "1"),
+      VideoPathWithId(Paths.get("domain/dans/user/utest/presentation/2"), "2")
+    )
   }
 
-  it should "succeed if the number of subtitles '2' is equal to the number of videos in the presentation '2'" in {
-    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(Paths.get("domain/dans/user/utest/presentation/3"), List(Paths.get("1"), Paths.get("2"))) shouldBe a[Success[_]]
+  "validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles" should "should return a Success if both list have the same length" in {
+    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles( List("1"), List(Paths.get("1"))) shouldBe a[Success[_]]
   }
 
-  it should "fail if the number of subtitles '2' is not equal to number of videos in the presentation '0'" in {
-    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(Paths.get("domain/dans/user/utest/presentation/1"), List(Paths.get("1"), Paths.get("2"))) should matchPattern {
-      case Failure(e: IllegalArgumentException) if e.getMessage == "The provided number of subtitles '2' did not match the number of videos in the presentation '0'" =>
+  it should "fail if there are more ids than paths" in {
+    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(List("1", "2"), List(Paths.get("1"))) should matchPattern {
+      case Failure(e: IllegalArgumentException) if e.getMessage == "The provided number of subtitles '1' did not match the number of videos in the presentation '2'" =>
     }
   }
 
-  it should "fail if the number of subtitles '0' is not equal to number of videos in the presentation '2'" in {
-    validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(Paths.get("domain/dans/user/utest/presentation/3"), List()) should matchPattern {
-      case Failure(e: IllegalArgumentException) if e.getMessage == "The provided number of subtitles '0' did not match the number of videos in the presentation '2'" =>
+    it should "fail if there are more paths than ids" in {
+      validateNumberOfVideosInPresentationIsEqualToNumberOfSubtitles(List("1"), List(Paths.get("1"), Paths.get("2"))) should matchPattern {
+        case Failure(e: IllegalArgumentException) if e.getMessage == "The provided number of subtitles '2' did not match the number of videos in the presentation '1'" =>
+      }
     }
+
+  "getVideoIdsForPresentation" should "return a list with the ids as String" in {
+    getVideoIdsForPresentation(Paths.get("3")) shouldBe Success(List("1", "2", "id that contains words"))
+  }
+
+  it should "return return an empty list if the presentation has no videos" in {
+    getVideoIdsForPresentation(Paths.get("private_continuous")) shouldBe Success(List())
   }
 
   private def createExceptionMessage(path: String): String = s"$path does not appear to be a presentation referid or Springfield path. Expected format: [domain/<d>/]user/<u>/presentation/<number> OR [domain/<d>/]user/<u>/collection/<c>/presentation/<p>"


### PR DESCRIPTION
fixes EASY-2131

#### When applied it will

- [x]  merge[23](https://github.com/DANS-KNAW/easy-springfield/pull/23) first

- [x] refactor a bit once 23 is merged

* you can now add subtitles to presentations with video names

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

How should this be manually tested?

Checkout this branch and build the rpm using mvnci

edit DTAP so that a new presentation will be added with videos with other id names.

go to the dtap directory of your computer . cd ~/git/dtap/easy-dtap. Start both dstreaming and deasy: vagrant up --no-provision dstreaming; vagrant up --no-provision deasy`.

deploy the role to dstreaming ./deploy-role.sh easy-springfield dstreaming.



Go to dstreaming using vagrant ssh dstreaming.

In dstreaming swap to the tomcat user and go to its home dir sudo -u tomcat /bin/sh; cd.

Copy some existing vvt files to the home dir:

cp /data/dansstreaming/domain/dans/user/utest/video/5/*priv* .

and rename one of language branded vvtfiles to a plain one cp fr_private_subtitles_fr.vvt private_subtitles.vvt.

Optionally you can change the content of the webvvt file using vi private_subtitles.vvt.

now we are going to add subtitles to the /domain/dans/user/utest/collection/ctest/presentation/private_continuous presentation
*check the current subtitles in the xml by naviagting to http://dstreaming.dans.knaw.nl:8080/smithers2/domain/dans/user/utest/presentation/1

you can see there are no subtitles there currently

Now run the following command /opt/bin/easy-springfield add-subtitles-to-presentation --language en domain/dans/user/utest/collection/ctest/presentation/private_continuous private_subtitles.vtt this should fail since the presentation has two videos

Now run the following command /opt/bin/easy-springfield add-subtitles-to-presentation --language en domain/dans/user/utest/collection/ctest/presentation/private_continuous private_subtitles.vtt private_subtitles.vtt this should succeed

Now run the following command /opt/bin/easy-springfield add-subtitles-to-presentation --language en domain/dans/user/utest/collection/ctest/presentation/multi-sub private_subtitles.vtt private_subtitles.vtt this should fail since it expects only one subtitle

Now run the following command /opt/bin/easy-springfield add-subtitles-to-presentation --language en domain/dans/user/utest/collection/ctest/presentation/multi-sub private_subtitles.vtt this should succeed

verify if the element is added by browsing to http://dstreaming.dans.knaw.nl:8080/smithers2/domain/dans/user/utest/presentation/1.

If this is correct browse to http://deasy.dans.knaw.nl/ui/datasets/id/easy-dataset:13/tab/1 and verify that the movie now has the subtitles that you added. Also verify if it indeed does display the content of your altered subtitles.

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 