### PR TITLE
EASY-2179: update scalatra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/test/scala/nl.knaw.dans.easy.springfield/AddSubtitlesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/AddSubtitlesSpec.scala
@@ -18,9 +18,11 @@ package nl.knaw.dans.easy.springfield
 import java.net.URI
 import java.nio.file.{ Path, Paths }
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class AddSubtitlesSpec extends FlatSpec with Matchers with CustomMatchers with AddSubtitles with Smithers2 {
+
+class AddSubtitlesSpec extends AnyFlatSpec with Matchers with CustomMatchers with AddSubtitles with Smithers2 {
   override val springFieldDataDir: Path = Paths.get("/data/dansstreaming")
   override val smithers2BaseUri: URI = new URI("http://localhost:8080/smithers2/")
   override val smithers2ConnectionTimeoutMs: Int = 100000

--- a/src/test/scala/nl.knaw.dans.easy.springfield/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/ReadmeSpec.scala
@@ -19,9 +19,10 @@ import java.io.{ ByteArrayOutputStream, File }
 import java.nio.file.Paths
 
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
+class ReadmeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   val mockedConfigurationProperties = new PropertiesConfiguration() {
     setDelimiterParsingDisabled(true)

--- a/src/test/scala/nl.knaw.dans.easy.springfield/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.springfield/TestSupportFixture.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.springfield
 
-import org.scalatest.{ FlatSpec, Matchers, OneInstancePerTest }
+import org.scalatest.OneInstancePerTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-trait TestSupportFixture extends FlatSpec with Matchers with OneInstancePerTest
+trait TestSupportFixture extends AnyFlatSpec with Matchers with OneInstancePerTest


### PR DESCRIPTION
fixes EASY-2179

#### When applied it will
* update parent POM version
* fix deprecation warnings

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | Note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     |